### PR TITLE
Add editable DAG workflow editor

### DIFF
--- a/src/app/api/workflow/route.ts
+++ b/src/app/api/workflow/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+const WORKFLOW_FILE_PATH = path.join(process.cwd(), "src", "data", "workflow.json");
+
+type WorkflowNode = {
+  id: string;
+  name: string;
+  position: { x: number; y: number };
+};
+
+type WorkflowEdge = {
+  id: string;
+  source: string;
+  target: string;
+};
+
+type Workflow = {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+};
+
+function isValidWorkflow(workflow: unknown): workflow is Workflow {
+  if (!workflow || typeof workflow !== "object") {
+    return false;
+  }
+
+  const { nodes, edges } = workflow as Workflow;
+
+  const nodesValid =
+    Array.isArray(nodes) &&
+    nodes.every(
+      (node) =>
+        node &&
+        typeof node === "object" &&
+        typeof node.id === "string" &&
+        typeof node.name === "string" &&
+        node.position &&
+        typeof node.position === "object" &&
+        typeof node.position.x === "number" &&
+        typeof node.position.y === "number"
+    );
+
+  const edgesValid =
+    Array.isArray(edges) &&
+    edges.every(
+      (edge) =>
+        edge &&
+        typeof edge === "object" &&
+        typeof edge.id === "string" &&
+        typeof edge.source === "string" &&
+        typeof edge.target === "string"
+    );
+
+  return nodesValid && edgesValid;
+}
+
+export async function GET() {
+  try {
+    const fileContents = await fs.readFile(WORKFLOW_FILE_PATH, "utf-8");
+    const workflow = JSON.parse(fileContents) as Workflow;
+    return NextResponse.json(workflow);
+  } catch (error) {
+    console.error("Failed to read workflow file", error);
+    return NextResponse.json({ error: "Failed to read workflow" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const workflow = (await request.json()) as unknown;
+
+    if (!isValidWorkflow(workflow)) {
+      return NextResponse.json({ error: "Invalid workflow format" }, { status: 400 });
+    }
+
+    await fs.writeFile(WORKFLOW_FILE_PATH, JSON.stringify(workflow, null, 2));
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    console.error("Failed to save workflow file", error);
+    return NextResponse.json({ error: "Failed to save workflow" }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,266 @@
-import Image from "next/image";
+"use client";
 
-export default function Home() {
+import { useCallback, useEffect, useMemo, useState } from "react";
+import ReactFlow, {
+  Background,
+  Connection,
+  Controls,
+  Edge,
+  MiniMap,
+  Node,
+  addEdge,
+  useEdgesState,
+  useNodesState,
+} from "reactflow";
+import "reactflow/dist/style.css";
+
+type WorkflowNode = {
+  id: string;
+  name: string;
+  position: { x: number; y: number };
+};
+
+type WorkflowEdge = {
+  id: string;
+  source: string;
+  target: string;
+};
+
+type Workflow = {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+};
+
+type FlowNode = Node<{ label: string }>;
+type FlowEdge = Edge;
+
+function mapWorkflowToNodes(nodes: WorkflowNode[]): FlowNode[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    position: node.position,
+    data: { label: node.name },
+    type: "default",
+  }));
+}
+
+function mapNodesToWorkflow(nodes: FlowNode[]): WorkflowNode[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    name: typeof node.data?.label === "string" ? node.data.label : "",
+    position: node.position,
+  }));
+}
+
+function mapWorkflowToEdges(edges: WorkflowEdge[]): FlowEdge[] {
+  return edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    type: "default",
+  }));
+}
+
+function mapEdgesToWorkflow(edges: FlowEdge[]): WorkflowEdge[] {
+  return edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+  }));
+}
+
+export default function Page() {
+  const [nodes, setNodes, onNodesChange] = useNodesState<FlowNode>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<FlowEdge>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchWorkflow = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/workflow");
+        if (!response.ok) {
+          throw new Error("Failed to load workflow");
+        }
+
+        const workflow = (await response.json()) as Workflow;
+        if (!isMounted) {
+          return;
+        }
+
+        setNodes(mapWorkflowToNodes(workflow.nodes));
+        setEdges(mapWorkflowToEdges(workflow.edges));
+        setSelectedNodeId(workflow.nodes[0]?.id ?? null);
+        setError(null);
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : "Failed to load workflow");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchWorkflow();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [setEdges, setNodes]);
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      setEdges((eds) =>
+        addEdge(
+          {
+            ...connection,
+            id: `edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          },
+          eds,
+        ),
+      );
+    },
+    [setEdges],
+  );
+
+  const onNodeSelectionChange = useCallback((selectedNodes: FlowNode[]) => {
+    setSelectedNodeId(selectedNodes[0]?.id ?? null);
+  }, []);
+
+  const handleSelectionChange = useCallback(
+    ({ nodes: selectedNodes }: { nodes: FlowNode[]; edges: FlowEdge[] }) => {
+      onNodeSelectionChange(selectedNodes);
+    },
+    [onNodeSelectionChange],
+  );
+
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId) ?? null,
+    [nodes, selectedNodeId],
+  );
+
+  const handleNameChange = useCallback(
+    (name: string) => {
+      if (!selectedNodeId) {
+        return;
+      }
+
+      setNodes((currentNodes) =>
+        currentNodes.map((node) =>
+          node.id === selectedNodeId
+            ? { ...node, data: { ...node.data, label: name } }
+            : node,
+        ),
+      );
+    },
+    [selectedNodeId, setNodes],
+  );
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaveMessage(null);
+    setError(null);
+
+    try {
+      const workflow: Workflow = {
+        nodes: mapNodesToWorkflow(nodes),
+        edges: mapEdgesToWorkflow(edges),
+      };
+
+      const response = await fetch("/api/workflow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(workflow),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to save workflow");
+      }
+
+      setSaveMessage("Workflow saved successfully.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save workflow");
+    } finally {
+      setSaving(false);
+    }
+  }, [edges, nodes]);
+
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="flex h-screen flex-col bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 px-6 py-4">
+        <h1 className="text-2xl font-semibold">DAG Workflow Editor</h1>
+        <p className="text-sm text-slate-400">
+          Load, edit, and save your workflow defined in <code>src/data/workflow.json</code>.
+        </p>
+      </header>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden p-4 md:flex-row">
+        <section className="flex-1 min-h-[360px] overflow-hidden rounded-lg border border-slate-800 bg-slate-900">
+          {loading ? (
+            <div className="flex h-full items-center justify-center text-slate-300">
+              Loading workflow...
+            </div>
+          ) : (
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              onSelectionChange={handleSelectionChange}
+              fitView
+              proOptions={{ hideAttribution: true }}
+              className="bg-slate-950"
+            >
+              <Background color="#64748b" gap={24} />
+              <MiniMap pannable zoomable />
+              <Controls />
+            </ReactFlow>
+          )}
+        </section>
+
+        <aside className="flex w-full max-w-md flex-col gap-4 rounded-lg border border-slate-800 bg-slate-900 p-4">
+          <h2 className="text-lg font-semibold">Node Details</h2>
+          {selectedNode ? (
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-300" htmlFor="node-name">
+                Node name
+              </label>
+              <input
+                id="node-name"
+                type="text"
+                value={typeof selectedNode.data?.label === "string" ? selectedNode.data.label : ""}
+                onChange={(event) => handleNameChange(event.target.value)}
+                className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/40"
+              />
+              <p className="text-xs text-slate-400">Select a node to edit its name.</p>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-400">Select a node in the graph to edit its name.</p>
+          )}
+
+          <div className="mt-auto space-y-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="w-full rounded-md bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-indigo-400/60"
+            >
+              {saving ? "Saving..." : "Save workflow"}
+            </button>
+            {saveMessage ? <p className="text-xs text-emerald-400">{saveMessage}</p> : null}
+            {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          </div>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/data/workflow.json
+++ b/src/data/workflow.json
@@ -1,0 +1,23 @@
+{
+  "nodes": [
+    {
+      "id": "1",
+      "name": "Start",
+      "position": { "x": 0, "y": 0 }
+    },
+    {
+      "id": "2",
+      "name": "Process",
+      "position": { "x": 250, "y": 0 }
+    },
+    {
+      "id": "3",
+      "name": "End",
+      "position": { "x": 500, "y": 0 }
+    }
+  ],
+  "edges": [
+    { "id": "e1-2", "source": "1", "target": "2" },
+    { "id": "e2-3", "source": "2", "target": "3" }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the landing page with a React Flow-based DAG editor that loads the workflow definition from disk
- add an API route that exposes the workflow JSON for reading and saving edits
- seed the project with an example workflow.json containing nodes and edges

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e018c9abac8331af0130d7b863614e