### PR TITLE
Fix hydration mismatch caused by runtime body attributes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import BodyHydrationFix from "@/components/body-hydration-fix";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -25,8 +27,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <BodyHydrationFix />
         {children}
       </body>
     </html>

--- a/src/components/body-hydration-fix.tsx
+++ b/src/components/body-hydration-fix.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+
+const BODY_SHORTCUT_ATTRIBUTE = "cz-shortcut-listen";
+
+export default function BodyHydrationFix() {
+  useEffect(() => {
+    const body = document.body;
+    if (!body) {
+      return;
+    }
+
+    if (body.hasAttribute(BODY_SHORTCUT_ATTRIBUTE)) {
+      body.removeAttribute(BODY_SHORTCUT_ATTRIBUTE);
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- import a client-side fix in the root layout to clean up runtime `cz-shortcut-listen` attributes added to the `<body>` element
- allow the body element to suppress hydration warnings so the server and client markup remain aligned during React hydration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01e28d98c8331b29f4692283a00ad