### PR TITLE
Implement sequential Python node workflow

### DIFF
--- a/src/app/api/workflow/route.ts
+++ b/src/app/api/workflow/route.ts
@@ -6,7 +6,9 @@ const WORKFLOW_FILE_PATH = path.join(process.cwd(), "src", "data", "workflow.jso
 
 type WorkflowNode = {
   id: string;
-  name: string;
+  file: string;
+  input: string;
+  output: string;
   position: { x: number; y: number };
 };
 
@@ -35,7 +37,9 @@ function isValidWorkflow(workflow: unknown): workflow is Workflow {
         node &&
         typeof node === "object" &&
         typeof node.id === "string" &&
-        typeof node.name === "string" &&
+        typeof node.file === "string" &&
+        typeof node.input === "string" &&
+        typeof node.output === "string" &&
         node.position &&
         typeof node.position === "object" &&
         typeof node.position.x === "number" &&

--- a/src/data/workflow.json
+++ b/src/data/workflow.json
@@ -1,23 +1,29 @@
 {
   "nodes": [
     {
-      "id": "1",
-      "name": "Start",
+      "id": "node-1",
+      "file": "load_data.py",
+      "input": "",
+      "output": "seed: start",
       "position": { "x": 0, "y": 0 }
     },
     {
-      "id": "2",
-      "name": "Process",
-      "position": { "x": 250, "y": 0 }
+      "id": "node-2",
+      "file": "transform_data.py",
+      "input": "seed: start",
+      "output": "seed: start -> transformed",
+      "position": { "x": 280, "y": 0 }
     },
     {
-      "id": "3",
-      "name": "End",
-      "position": { "x": 500, "y": 0 }
+      "id": "node-3",
+      "file": "save_results.py",
+      "input": "seed: start -> transformed",
+      "output": "workflow complete",
+      "position": { "x": 560, "y": 0 }
     }
   ],
   "edges": [
-    { "id": "e1-2", "source": "1", "target": "2" },
-    { "id": "e2-3", "source": "2", "target": "3" }
+    { "id": "e-node-1-node-2", "source": "node-1", "target": "node-2" },
+    { "id": "e-node-2-node-3", "source": "node-2", "target": "node-3" }
   ]
 }

--- a/src/workflow/nodes/load_data.py
+++ b/src/workflow/nodes/load_data.py
@@ -1,0 +1,9 @@
+"""Example starting node for the sample workflow."""
+
+def run(input_data=None):
+    """Produce the initial payload for the workflow."""
+    output = {
+        "message": "seed: start",
+        "step": 1,
+    }
+    return output

--- a/src/workflow/nodes/save_results.py
+++ b/src/workflow/nodes/save_results.py
@@ -1,0 +1,8 @@
+"""Persist the transformed payload and return a final status."""
+
+def run(input_data):
+    """Return a completion summary for the workflow."""
+    return {
+        "status": "workflow complete",
+        "received": input_data,
+    }

--- a/src/workflow/nodes/transform_data.py
+++ b/src/workflow/nodes/transform_data.py
@@ -1,0 +1,19 @@
+"""Transform the payload emitted by ``load_data``."""
+
+def run(input_data):
+    """Append processing metadata to the incoming payload."""
+    if input_data is None:
+        input_data = {}
+
+    message = input_data.get("message", "")
+    if message:
+        message = f"{message} -> transformed"
+    else:
+        message = "transformed"
+
+    enriched = {
+        **input_data,
+        "message": message,
+        "step": input_data.get("step", 0) + 1,
+    }
+    return enriched


### PR DESCRIPTION
## Summary
- update the workflow schema to treat nodes as Python files with explicit input/output values
- enhance the editor UI to manage sequential Python nodes and propagate outputs downstream
- add example Python node scripts that demonstrate a simple linear workflow

## Testing
- npm run build *(fails: next/font unable to download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e020596f648331b1754009ba975013