### PR TITLE
Add sequential workflow runner and UI updates

### DIFF
--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { execFile } from "child_process";
+import path from "path";
+
+const ORCHESTRATOR_PATH = path.join(process.cwd(), "src", "workflow", "orchestrator.py");
+
+function runOrchestrator(): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile("python3", [ORCHESTRATOR_PATH], { cwd: process.cwd() }, (error, stdout, stderr) => {
+      if (error) {
+        reject({ error, stdout, stderr });
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+export async function POST() {
+  try {
+    const { stdout } = await runOrchestrator();
+    const payload = JSON.parse(stdout || "{}") as { result?: unknown; error?: string };
+
+    if (payload.error) {
+      return NextResponse.json({ error: payload.error }, { status: 500 });
+    }
+
+    return NextResponse.json({ result: payload.result ?? null });
+  } catch (err) {
+    const message =
+      err && typeof err === "object" && "stderr" in err && typeof err.stderr === "string"
+        ? err.stderr || "Failed to run workflow"
+        : err instanceof Error
+          ? err.message
+          : "Failed to run workflow";
+
+    console.error("Workflow execution failed", err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/workflow/route.ts
+++ b/src/app/api/workflow/route.ts
@@ -7,8 +7,6 @@ const WORKFLOW_FILE_PATH = path.join(process.cwd(), "src", "data", "workflow.jso
 type WorkflowNode = {
   id: string;
   file: string;
-  input: string;
-  output: string;
   position: { x: number; y: number };
 };
 
@@ -38,8 +36,6 @@ function isValidWorkflow(workflow: unknown): workflow is Workflow {
         typeof node === "object" &&
         typeof node.id === "string" &&
         typeof node.file === "string" &&
-        typeof node.input === "string" &&
-        typeof node.output === "string" &&
         node.position &&
         typeof node.position === "object" &&
         typeof node.position.x === "number" &&

--- a/src/data/workflow.json
+++ b/src/data/workflow.json
@@ -3,22 +3,16 @@
     {
       "id": "node-1",
       "file": "load_data.py",
-      "input": "",
-      "output": "seed: start",
       "position": { "x": 0, "y": 0 }
     },
     {
       "id": "node-2",
       "file": "transform_data.py",
-      "input": "seed: start",
-      "output": "seed: start -> transformed",
       "position": { "x": 280, "y": 0 }
     },
     {
       "id": "node-3",
       "file": "save_results.py",
-      "input": "seed: start -> transformed",
-      "output": "workflow complete",
       "position": { "x": 560, "y": 0 }
     }
   ],

--- a/src/workflow/orchestrator.py
+++ b/src/workflow/orchestrator.py
@@ -1,0 +1,77 @@
+"""Run the configured workflow sequentially."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List
+
+BASE_DIR = Path(__file__).resolve().parent
+WORKFLOW_FILE = BASE_DIR.parent / "data" / "workflow.json"
+NODES_DIR = BASE_DIR / "nodes"
+
+
+class WorkflowError(RuntimeError):
+    """Raised when the workflow configuration or execution fails."""
+
+
+def _load_module_from_path(module_path: Path) -> ModuleType:
+    if not module_path.exists():
+        raise WorkflowError(f"Node file not found: {module_path}")
+
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    if spec is None or spec.loader is None:
+        raise WorkflowError(f"Unable to load module from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[misc]
+    return module
+
+
+def run_workflow() -> Dict[str, Any]:
+    try:
+        workflow_data = json.loads(WORKFLOW_FILE.read_text())
+    except FileNotFoundError as exc:
+        raise WorkflowError(f"Workflow file not found: {WORKFLOW_FILE}") from exc
+    except json.JSONDecodeError as exc:
+        raise WorkflowError("Workflow file is not valid JSON") from exc
+
+    nodes: List[Dict[str, Any]] = workflow_data.get("nodes", [])
+    if not isinstance(nodes, list) or not nodes:
+        raise WorkflowError("Workflow must contain at least one node")
+
+    result: Any = None
+    for node in nodes:
+        if not isinstance(node, dict):
+            raise WorkflowError("Invalid node definition encountered")
+
+        file_name = node.get("file")
+        if not isinstance(file_name, str) or not file_name:
+            raise WorkflowError("Node is missing a valid 'file' entry")
+
+        module_path = NODES_DIR / file_name
+        module = _load_module_from_path(module_path)
+        run_callable = getattr(module, "run", None)
+        if not callable(run_callable):
+            raise WorkflowError(f"Node '{file_name}' does not define a callable 'run' function")
+
+        result = run_callable(result)
+
+    return {"result": result}
+
+
+def main() -> None:
+    try:
+        payload = run_workflow()
+    except WorkflowError as exc:
+        output = {"error": str(exc)}
+    else:
+        output = payload
+
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- simplify workflow nodes to only capture the Python file name and refresh the editor UI with a Run action
- add an API endpoint that triggers a Python orchestrator to execute the linear workflow and surface the result to the UI
- implement a Python-based orchestrator that loads the workflow JSON and chains each node's run() output into the next

## Testing
- python3 src/workflow/orchestrator.py
- npm run build *(fails: Next.js cannot fetch Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0235c329083319668f1050553b6f4