### PR TITLE
Handle Python executable lookup in workflow runner

### DIFF
--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -4,16 +4,61 @@ import path from "path";
 
 const ORCHESTRATOR_PATH = path.join(process.cwd(), "src", "workflow", "orchestrator.py");
 
-function runOrchestrator(): Promise<{ stdout: string; stderr: string }> {
+type ExecError = NodeJS.ErrnoException & {
+  stdout?: string;
+  stderr?: string;
+};
+
+const PYTHON_EXECUTABLES = Array.from(
+  new Set(
+    [
+      process.env.PYTHON,
+      process.env.PYTHON_PATH,
+      "python3",
+      "python",
+      process.platform === "win32" ? "py" : undefined,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0)
+  )
+);
+
+function execOrchestrator(pythonExecutable: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    execFile("python3", [ORCHESTRATOR_PATH], { cwd: process.cwd() }, (error, stdout, stderr) => {
+    execFile(pythonExecutable, [ORCHESTRATOR_PATH], { cwd: process.cwd() }, (error, stdout, stderr) => {
       if (error) {
-        reject({ error, stdout, stderr });
+        reject(Object.assign(error, { stdout, stderr }));
         return;
       }
       resolve({ stdout, stderr });
     });
   });
+}
+
+async function runOrchestrator(): Promise<{ stdout: string; stderr: string }> {
+  let lastError: ExecError | null = null;
+
+  for (const executable of PYTHON_EXECUTABLES) {
+    try {
+      return await execOrchestrator(executable);
+    } catch (error) {
+      if (isExecError(error) && error.code === "ENOENT") {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error(
+    "Unable to locate a Python executable. Install Python or set the PYTHON environment variable."
+  );
+}
+
+function isExecError(error: unknown): error is ExecError {
+  return Boolean(error) && typeof error === "object" && "code" in error;
 }
 
 export async function POST() {
@@ -27,12 +72,21 @@ export async function POST() {
 
     return NextResponse.json({ result: payload.result ?? null });
   } catch (err) {
-    const message =
-      err && typeof err === "object" && "stderr" in err && typeof err.stderr === "string"
-        ? err.stderr || "Failed to run workflow"
-        : err instanceof Error
-          ? err.message
-          : "Failed to run workflow";
+    const message = (() => {
+      if (isExecError(err) && err.code === "ENOENT") {
+        return "Python executable not found. Install Python and ensure it is on your PATH.";
+      }
+
+      if (err && typeof err === "object" && "stderr" in err && typeof err.stderr === "string") {
+        return err.stderr || "Failed to run workflow";
+      }
+
+      if (err instanceof Error) {
+        return err.message;
+      }
+
+      return "Failed to run workflow";
+    })();
 
     console.error("Workflow execution failed", err);
     return NextResponse.json({ error: message }, { status: 500 });


### PR DESCRIPTION
## Summary
- add cross-platform Python executable resolution before invoking the workflow orchestrator
- surface clearer error messaging when Python is missing or the orchestrator reports stderr output

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0268bb6a88331a0fbe6f16e3d3413